### PR TITLE
Rework: privilege escalation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,8 +4,10 @@
     name: chronyd
     state: started
     enabled: yes
+  become: yes
 
 - name: Restart chronyd
   service:
     name: chronyd
     state: restarted
+  become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   package:
     name: chrony
     state: present
+  become: yes
   notify: Enable and Start chronyd
   tags:
     - time
@@ -16,6 +17,7 @@
     owner: root
     group: root
     mode: 0644
+  become: yes
   notify: Restart chronyd
   tags:
     - time


### PR DESCRIPTION
# Rework: privilege escalation

Use "become: yes" where necessary.
This way the role itself doesn't need to be escalated anymore.

## Reference
<!--
Please be aware, that every pull-request/merge-request for released (stable) repositories needs an issue.
-->
 - Resolves: #11 
 - See also:

## (Optional) People
<!--
@mentions of somebody who was involved or should be involved.
@mentions of the person or team responsible for reviewing proposed changes.
-->
